### PR TITLE
Feature/Add TTL to get() method

### DIFF
--- a/rndi/cache/adapters/null/adapter.py
+++ b/rndi/cache/adapters/null/adapter.py
@@ -16,11 +16,11 @@ class NullCacheAdapter(Cache):  # pragma: no cover
     def has(self, key: str) -> bool:
         return False
 
-    def get(self, key: str, default: Any = None) -> Any:
+    def get(self, key: str, default: Any = None, ttl: Optional[int] = None) -> Any:
         value = default() if callable(default) else default
 
         if isinstance(value, tuple):
-            value, ttl = value
+            value, _ = value
 
         return value
 

--- a/rndi/cache/contracts/__init__.py
+++ b/rndi/cache/contracts/__init__.py
@@ -18,7 +18,7 @@ class Cache(metaclass=ABCMeta):  # pragma: no cover
         """
 
     @abstractmethod
-    def get(self, key: str, default: Any = None) -> Any:
+    def get(self, key: str, default: Any = None, ttl: Optional[int] = None) -> Any:
         """
         Get the required value by key from the cache.
         :param key: str The key of the stored value.
@@ -29,6 +29,7 @@ class Cache(metaclass=ABCMeta):  # pragma: no cover
                         seconds. The callable may return a Tuple[Any, int]
                         with the actual value as first element and the desired
                         expired time as second value.
+        :param ttl: int Time to live in seconds.
         :return: Any The requested value by key.
         """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,24 +3,30 @@
 #
 # Copyright (c) 2023 Ingram Micro. All Rights Reserved.
 #
-from typing import List
+from abc import ABCMeta, abstractmethod
+from typing import Dict, List, Optional, Union
 from logging import LoggerAdapter
 from unittest.mock import patch
 
 import pytest
+from rndi.cache.adapters.fs.adapter import FileSystemCacheAdapter, get_file_contents
 from rndi.cache.contracts import Cache
 from rndi.cache.provider import provide_cache
 
 
 @pytest.fixture
 def adapters(logger):
-    def __adapters() -> List[Cache]:
+    def __adapters() -> List[Union[Cache, HasEntry]]:
         setups = [
             {'CACHE_DRIVER': 'file', 'CACHE_DIR': '/tmp'},
             {'CACHE_DRIVER': 'none'},
         ]
 
-        return [provide_cache(setup, logger()) for setup in setups]
+        extra = {
+            'file': provide_test_fs_cache_adapter,
+        }
+
+        return [provide_cache(setup, logger(), extra) for setup in setups]
 
     return __adapters
 
@@ -32,3 +38,33 @@ def logger():
             return logger
 
     return __logger
+
+
+class HasEntry(metaclass=ABCMeta):  # pragma: no cover
+    @abstractmethod
+    def get_entry(self, key: str) -> Optional[Dict[str, Union[str, int]]]:
+        """
+        Get an entry from the cache, not only the value.
+        This is useful for testing purposes when we want to validate the TTL.
+        :param key: str The key to search for.
+        :return: Optional[Dict[str, Union[str, int]]] The entry if found, None otherwise.
+        """
+
+
+class FileSystemCacheAdapterTester(FileSystemCacheAdapter, HasEntry):
+    def get_entry(self, key: str) -> Optional[Dict[str, Union[str, int]]]:
+        cache_file = self._get_file_name(key)
+
+        content = get_file_contents(cache_file)
+
+        return {
+            'value': content['value'],
+            'expire_at': content['expire_at'],
+        }
+
+
+def provide_test_fs_cache_adapter(config: dict) -> Cache:
+    return FileSystemCacheAdapterTester(
+        directory_path=config.get('CACHE_DIR', '/tmp/cache'),
+        ttl=config.get('CACHE_TTL', 900),
+    )

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2023 Ingram Micro. All Rights Reserved.
 #
+import time
+
 from rndi.cache.adapters.null.adapter import NullCacheAdapter
 
 COUNT = 0
@@ -71,6 +73,17 @@ def test_adapter_cache_should_flush_all_values(adapters):
         assert not adapter.has('b')
         assert not adapter.has('c')
         assert not adapter.has('d')
+
+
+def test_adapter_cache_get_should_update_expiration_if_provided(adapters):
+    for adapter in adapters():
+        adapter.put('x', 'some-value-1')
+        adapter.get('x', ttl=300)
+
+        if isinstance(adapter, NullCacheAdapter):
+            assert not adapter.has('x')
+        else:
+            assert adapter.get_entry('x').get('expire_at') == round(time.time() + 300)
 
 
 def test_adapter_cache_should_flush_only_expired_values(adapters):


### PR DESCRIPTION
* Rename _get_file_contents to get_file_contents, it is now a public method and can be reused for testing purposes.

* Added TTL parameter to get() method. Now if a ttl is provided, the entry will be updated with the given ttl if it exists.

* Added HasEntry contract for testing purposes, so we can get the full entry.